### PR TITLE
config 初期化

### DIFF
--- a/src/laoplus.user.js
+++ b/src/laoplus.user.js
@@ -21,10 +21,6 @@
 // @supportURL  https://github.com/eai04191/laoplus/issues
 // ==/UserScript==
 
-if (typeof window._ === 'undefined') {
-    require('_', 'lodash');
-}
-
 const log = (name, ...args) => {
     // eslint-disable-next-line no-console
     console.log(

--- a/src/laoplus.user.js
+++ b/src/laoplus.user.js
@@ -140,19 +140,15 @@ const addLaoplusButton = () => {
 };
 addLaoplusButton();
 
-const config = GM_getValue("config") || {
-    "features" : {
-        "discordNotification": {
-            "enabled": false,
-            "webhookURL": ""
-        }
-    }
+const defaultConfig = {
+    features: {
+        discordNotification: {
+            enabled: false,
+            webhookURL: "",
+        },
+    },
 };
-if (!GM_getValue("config")) {
-    log("Setting", "Config not found. Initialize...", config);
-    GM_setValue("config", config);
-    log("Setting", "Config Saved", config);
-}
+const config = GM_getValue("config", defaultConfig);
 log("Config", "Config Loaded", config);
 
 MicroModal.init({

--- a/src/laoplus.user.js
+++ b/src/laoplus.user.js
@@ -21,6 +21,10 @@
 // @supportURL  https://github.com/eai04191/laoplus/issues
 // ==/UserScript==
 
+if (typeof window._ === 'undefined') {
+    require('_', 'lodash');
+}
+
 const log = (name, ...args) => {
     // eslint-disable-next-line no-console
     console.log(
@@ -140,13 +144,16 @@ const addLaoplusButton = () => {
 };
 addLaoplusButton();
 
-const config = GM_getValue("config");
-if (config === undefined) {
+const config = GM_getValue("config") || {
+    "features" : {
+        "discordNotification": {
+            "enabled": false,
+            "webhookURL": ""
+        }
+    }
+};
+if (!GM_getValue("config")) {
     log("Setting", "Config not found. Initialize...", config);
-
-    _.set(config, "features.discordNotification.enabled", false);
-    _.set(config, "features.discordNotification.webhookURL", "");
-
     GM_setValue("config", config);
     log("Setting", "Config Saved", config);
 }

--- a/src/laoplus.user.js
+++ b/src/laoplus.user.js
@@ -31,7 +31,7 @@ const log = (name, ...args) => {
 };
 
 const url = new URL(document.URL);
-if (['pc-play.games.dmm.com', 'pc-play.games.dmm.co.jp'].includes(url.host)) {
+if (["pc-play.games.dmm.com", "pc-play.games.dmm.co.jp"].includes(url.host)) {
     document
         .querySelector(`link[rel="icon"]`)
         .setAttribute(


### PR DESCRIPTION
## 変更点

- (おそらく) lodash が生きてない気がしたので require しました
  - 書き方よくわからず汚いです……
- いきなり `_.set(config, "features.discordNotification.enabled", false);` すると key が `"features.discordNotification.enabled"` になるので初回だけ真面目にMapを構築しました

## 確認事項

- ダイアログ開閉 / wave_clear 時のエラーが起きなくなりました
- メニューからそれっぽい値が格納できました(ViolentMonkey の dashboard > 値)
  - ![image](https://user-images.githubusercontent.com/28837028/143673428-a0522b11-a830-481a-8cd8-90fe4981a15a.png)
- 無事に通知が来ました(ev2-7)
  - ![image](https://user-images.githubusercontent.com/28837028/143673440-517664ce-cedb-4868-88a6-8a435ff414f0.png)
