### PR TITLE
tsのpathを設定してモジュール名と被るファイルをインポートできるようにする

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
 
         "module": "ESNext",
         "baseUrl": "src",
+        "paths": {
+            "~/*": ["./*"]
+        },
         "moduleResolution": "node",
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
`constants.ts`のようなファイルをsrc/に置いて、別ファイルから
```ts
import { HOGE } from "constants";
```
のようにインポートしようとするとnodeのconstatsモジュールが読み込まれて使うことができない。

pathを設定すると
```ts
import { HOGE } from "~/constants";
```
のように明示的に自分が開きたいパスを指定できる