### PR TITLE
discordapp.comのWebhook URLもvalidとする

### DIFF
--- a/src/ui/components/ConfigModal/index.tsx
+++ b/src/ui/components/ConfigModal/index.tsx
@@ -130,7 +130,7 @@ export const ConfigModal = () => {
                                                 "features.discordNotification.enabled"
                                             ),
                                             pattern:
-                                                /^https:\/\/discord\.com\/api\/webhooks\//,
+                                                /^https:\/\/(discord\.com|discordapp\.com)\/api\/webhooks\//,
                                         }
                                     )}
                                 />


### PR DESCRIPTION
close #17 

## 確認したこと

- discord.comのウェブフックのホストをdiscordapp.comに書き換えて設定が保存できること
- disocrdapp.comへのウェブフックが正しく飛ぶこと