### PR TITLE
logをログレベルごとに出力する

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,6 @@ export class Config {
     set(value: DeepPartial<Config["config"]>) {
         _.merge(this.config, value);
         GM_setValue("config", this.config);
-        log("Config", "Config Updated", this.config);
+        log.log("Config", "Config Updated", this.config);
     }
 }

--- a/src/features/discordNotification/index.ts
+++ b/src/features/discordNotification/index.ts
@@ -4,7 +4,11 @@ export const sendToDiscordWebhook = (body: unknown) => {
     if (
         !unsafeWindow.LAOPLUS.config.config.features.discordNotification.enabled
     ) {
-        log.log("Discord Notification", "設定が無効のため送信しませんでした", body);
+        log.log(
+            "Discord Notification",
+            "設定が無効のため送信しませんでした",
+            body
+        );
         return;
     }
 

--- a/src/features/discordNotification/index.ts
+++ b/src/features/discordNotification/index.ts
@@ -4,7 +4,7 @@ export const sendToDiscordWebhook = (body: unknown) => {
     if (
         !unsafeWindow.LAOPLUS.config.config.features.discordNotification.enabled
     ) {
-        log("Discord Notification", "設定が無効のため送信しませんでした", body);
+        log.log("Discord Notification", "設定が無効のため送信しませんでした", body);
         return;
     }
 

--- a/src/features/discordNotification/index.ts
+++ b/src/features/discordNotification/index.ts
@@ -4,7 +4,7 @@ export const sendToDiscordWebhook = (body: unknown) => {
     if (
         !unsafeWindow.LAOPLUS.config.config.features.discordNotification.enabled
     ) {
-        log.log(
+        log.debug(
             "Discord Notification",
             "設定が無効のため送信しませんでした",
             body

--- a/src/features/explorationTimer/index.ts
+++ b/src/features/explorationTimer/index.ts
@@ -68,7 +68,7 @@ const sendNotification = (): void => {
     ) {
         sendToDiscordWebhook(body);
     } else {
-        log(
+        log.debug(
             "Exploration Timer",
             "設定が無効のため、Discord通知を送信しませんでした",
             body
@@ -97,7 +97,8 @@ export const explorationInginfo = ({
             return ex;
         }
     });
-    log(
+
+    log.log(
         "Exploration Timer",
         "Restore Exploration Timers",
         unsafeWindow.LAOPLUS.exploration
@@ -112,7 +113,8 @@ export const explorationEnter = ({
     const msToFinish = EnterInfo.EndTime * 1000 - Date.now();
     const timeoutID = window.setTimeout(sendNotification, msToFinish);
     unsafeWindow.LAOPLUS.exploration.push({ ...EnterInfo, timeoutID });
-    log(
+
+    log.log(
         "Exploration Timer",
         "Add Exploration Timer",
         unsafeWindow.LAOPLUS.exploration
@@ -127,7 +129,8 @@ export const explorationReward = ({
     unsafeWindow.LAOPLUS.exploration = unsafeWindow.LAOPLUS.exploration.filter(
         (ex) => ex.SquadIndex !== SquadIndex
     );
-    log(
+
+    log.log(
         "Exploration Timer",
         "Remove Exploration Timer",
         unsafeWindow.LAOPLUS.exploration
@@ -149,7 +152,8 @@ export const explorationCancel = ({
     unsafeWindow.LAOPLUS.exploration = unsafeWindow.LAOPLUS.exploration.filter(
         (ex) => ex.SquadIndex !== SquadIndex
     );
-    log(
+
+    log.log(
         "Exploration Timer",
         "Remove Exploration",
         unsafeWindow.LAOPLUS.exploration

--- a/src/features/interceptor/index.ts
+++ b/src/features/interceptor/index.ts
@@ -32,7 +32,7 @@ const interceptor = (xhr: XMLHttpRequest): void => {
     // JSONが不正なことがあるのでtry-catch
     try {
         const res = JSON.parse(responseText);
-        log("Interceptor", url.pathname, res);
+        log.debug("Interceptor", url.pathname, res);
 
         // TODO: このような処理をここに書くのではなく、各種機能がここを購読しに来るように分離したい
         if (url.pathname === "/wave_clear") {
@@ -73,7 +73,7 @@ const interceptor = (xhr: XMLHttpRequest): void => {
             ) {
                 sendToDiscordWebhook(body);
             } else {
-                log(
+                log.debug(
                     "Drop Notification",
                     "送信する項目がないか、設定が無効のため、Discord通知を送信しませんでした",
                     body
@@ -89,7 +89,7 @@ const interceptor = (xhr: XMLHttpRequest): void => {
             explorationCancel(res);
         }
     } catch (error) {
-        log("Interceptor", "Error", error);
+        log.log("Interceptor", "Error", error);
     }
 };
 

--- a/src/features/resizeObserver/index.ts
+++ b/src/features/resizeObserver/index.ts
@@ -2,7 +2,10 @@ import { log } from "utils/log";
 
 export const initResizeObserver = () => {
     const game = document.querySelector("canvas");
-    if (!game) return;
+    if (!game) {
+        log.error("ResizeObserver", "Game Canvas Not Found");
+        return;
+    }
     const body = document.body;
 
     const bodyResizeObserver = new ResizeObserver((entries) => {
@@ -10,19 +13,23 @@ export const initResizeObserver = () => {
         const { width, height } = entries[0].contentRect;
         game.height = height;
         game.width = width;
-        log("ResizeObserver", "Game resized:", `${game.width}x${game.height}`);
+        log.log(
+            "ResizeObserver",
+            "Game resized:",
+            `${game.width}x${game.height}`
+        );
     });
 
     const canvasAttributeObserver = new MutationObserver(() => {
         bodyResizeObserver.observe(body);
-        log(
+        log.log(
             "CanvasAttributeObserver",
             "Game initialized. ResizeObserver Started."
         );
         canvasAttributeObserver.disconnect();
-        log("CanvasAttributeObserver", "CanvasAttributeObserver Stopped.");
+        log.log("CanvasAttributeObserver", "CanvasAttributeObserver Stopped.");
     });
 
     canvasAttributeObserver.observe(game, { attributes: true });
-    log("CanvasAttributeObserver", "CanvasAttributeObserver Started.");
+    log.log("CanvasAttributeObserver", "CanvasAttributeObserver Started.");
 };

--- a/src/injection/dmmGame.ts
+++ b/src/injection/dmmGame.ts
@@ -31,5 +31,5 @@ export const initDMMGamePage = () => {
             width: 100vw !important;
     }`);
 
-    log.log("DMM Page", "Style injected.");
+    log.log("Injection", "DMM Page", "Style injected.");
 };

--- a/src/injection/dmmGame.ts
+++ b/src/injection/dmmGame.ts
@@ -31,5 +31,5 @@ export const initDMMGamePage = () => {
             width: 100vw !important;
     }`);
 
-    log("DMM Page", "Style injected.");
+    log.log("DMM Page", "Style injected.");
 };

--- a/src/injection/dmmInner.ts
+++ b/src/injection/dmmInner.ts
@@ -7,5 +7,5 @@ export const initDMMInnerPage = () => {
     frame.removeAttribute("height");
     frame.style.height = "100vh";
 
-    log("DMM Inner Page", "iframe Style injected.");
+    log.log("DMM Inner Page", "iframe Style injected.");
 };

--- a/src/injection/dmmInner.ts
+++ b/src/injection/dmmInner.ts
@@ -7,5 +7,5 @@ export const initDMMInnerPage = () => {
     frame.removeAttribute("height");
     frame.style.height = "100vh";
 
-    log.log("DMM Inner Page", "iframe Style injected.");
+    log.log("Injection", "DMM Inner Page", "iframe Style injected.");
 };

--- a/src/injection/game.ts
+++ b/src/injection/game.ts
@@ -15,5 +15,5 @@ export const initGamePage = () => {
         transform: unset;
     }`);
 
-    log.log("Game Page", "Style injected.");
+    log.log("Injection", "Game Page", "Style injected.");
 };

--- a/src/injection/game.ts
+++ b/src/injection/game.ts
@@ -15,5 +15,5 @@ export const initGamePage = () => {
         transform: unset;
     }`);
 
-    log("Game Page", "Style injected.");
+    log.log("Game Page", "Style injected.");
 };

--- a/src/tacticsManual.ts
+++ b/src/tacticsManual.ts
@@ -9,11 +9,11 @@ export const initTacticsManual = () => {
                 const parsedJson: {
                     [key: string]: string;
                 } = JSON.parse(responseText);
-                log("TacticsManual", "Locale", "Loaded");
+                log.log("TacticsManual", "Locale", "Loaded");
 
                 unsafeWindow.LAOPLUS.tacticsManual.locale = parsedJson;
             } catch (error) {
-                log("Tactics Manual", "Locale", "Error", error);
+                log.error("Tactics Manual", "Locale", "Error", error);
             }
         },
     });
@@ -24,11 +24,11 @@ export const initTacticsManual = () => {
             try {
                 const parsedJson: TacticsManualUnit[] =
                     JSON.parse(responseText);
-                log("TacticsManual", "Unit", "Loaded");
+                log.log("TacticsManual", "Unit", "Loaded");
 
                 unsafeWindow.LAOPLUS.tacticsManual.unit = parsedJson;
             } catch (error) {
-                log("Tactics Manual", "Unit", "Error", error);
+                log.error("Tactics Manual", "Unit", "Error", error);
             }
         },
     });

--- a/src/ui/components/ConfigModal/index.tsx
+++ b/src/ui/components/ConfigModal/index.tsx
@@ -39,13 +39,13 @@ export const ConfigModal = () => {
     });
 
     const onSubmit = (config: Config["config"]) => {
-        log("Config Modal", "Config submitted", config);
+        log.log("Config Modal", "Config submitted", config);
         unsafeWindow.LAOPLUS.config.set(config);
         setIsOpen(false);
     };
 
     if (!_.isEmpty(errors)) {
-        log("Config Modal", "Error!", errors);
+        log.log("Config Modal", "Error!", errors);
     }
 
     return (

--- a/src/ui/components/ConfigModal/index.tsx
+++ b/src/ui/components/ConfigModal/index.tsx
@@ -45,7 +45,7 @@ export const ConfigModal = () => {
     };
 
     if (!_.isEmpty(errors)) {
-        log.log("Config Modal", "Error!", errors);
+        log.error("Config Modal", "Error", errors);
     }
 
     return (

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -4,7 +4,11 @@ const style =
 
 export const log = {
     debug: (moduleName: string, ...args: unknown[]) => {
-        console.debug(`%c🐞LAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
+        console.debug(
+            `%c🐞LAOPLUS :: ${moduleName}`,
+            style,
+            ..._.cloneDeep(args)
+        );
     },
     log: (moduleName: string, ...args: unknown[]) => {
         console.log(`%cLAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
@@ -13,6 +17,10 @@ export const log = {
         console.warn(`%cLAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
     },
     error: (moduleName: string, ...args: unknown[]) => {
-        console.error(`%cLAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
+        console.error(
+            `%cLAOPLUS :: ${moduleName}`,
+            style,
+            ..._.cloneDeep(args)
+        );
     },
 };

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,8 +1,18 @@
-export const log = (name: string, ...args: unknown[]) => {
-    // eslint-disable-next-line no-console
-    console.log(
-        `%cLAOPLUS :: ${name}`,
-        "padding-right:.6rem;padding-left:.6rem;background:gray;color:white;border-radius:.25rem",
-        ...args
-    );
+/* eslint-disable no-console */
+const style =
+    "padding-right:.6rem;padding-left:.6rem;background:gray;color:white;border-radius:.25rem";
+
+export const log = {
+    debug: (moduleName: string, ...args: unknown[]) => {
+        console.debug(`%c🐞LAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
+    },
+    log: (moduleName: string, ...args: unknown[]) => {
+        console.log(`%cLAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
+    },
+    warn: (moduleName: string, ...args: unknown[]) => {
+        console.warn(`%cLAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
+    },
+    error: (moduleName: string, ...args: unknown[]) => {
+        console.error(`%cLAOPLUS :: ${moduleName}`, style, ..._.cloneDeep(args));
+    },
 };


### PR DESCRIPTION
インターフェースも`log()`から`log.log()`のように変更
ついでにargをcloneDeepして参照渡ししないように変更

log.debug()で出力されたものには 🐞 がつき、DevTools上でも[詳細]にチェックを入れないと表示されなくなる

![image](https://user-images.githubusercontent.com/3516343/144700975-7b35c903-5964-46eb-8036-b7da1e6593d9.png)


![image](https://user-images.githubusercontent.com/3516343/144700969-925ef6ae-4b79-43a2-ac33-6b5bd1278c74.png)
