### PR TITLE
Intl.NumberFormat を使ってロケールに合った小数点を使用する

### DIFF
--- a/src/ui/components/FarmingStats/ResourceCounter.tsx
+++ b/src/ui/components/FarmingStats/ResourceCounter.tsx
@@ -44,8 +44,11 @@ export const ResourceCounter: React.VFC<{
         return amount;
     })();
 
-    // displayAmountの小数部分
-    const dec = String(displayAmount).split(".")[1];
+    const nf = new Intl.NumberFormat();
+    const parts = nf.formatToParts(displayAmount);
+    const integer = parts.find((p) => p.type === "integer")?.value || 0;
+    const decimal = parts.find((p) => p.type === "decimal")?.value || ".";
+    const fraction = parts.find((p) => p.type === "fraction")?.value;
 
     return (
         <div className="flex items-center gap-2 font-bold text-gray-900">
@@ -62,11 +65,12 @@ export const ResourceCounter: React.VFC<{
             <span className={cn(sign && displayAmount < 0 && "text-red-500")}>
                 {sign &&
                     (displayAmount === 0 ? "±" : displayAmount < 0 ? "-" : "+")}
-                {Math.abs(Math.trunc(displayAmount)).toLocaleString()}
-                {dec && (
-                    // 日本や欧米以外では小数点が"."ではない可能性があるが
-                    // Number.prototype.toLocaleString()した結果のロケール定義を取得する方法がわからないため.に固定している
-                    <span className="ml-0.5 text-xs text-gray-500">.{dec}</span>
+                {integer}
+                {fraction && (
+                    <span className="ml-0.5 text-xs text-gray-500">
+                        {decimal}
+                        {fraction}
+                    </span>
                 )}
             </span>
         </div>


### PR DESCRIPTION
日本語ロケールの場合小数点が `.` になる

![2022-02-22_04-03-21_msedge](https://user-images.githubusercontent.com/3516343/155014018-5e046d24-81a0-40e4-86ad-b4cf3095769f.png)

ドイツロケールの場合小数点が `,` になる

![2022-02-22_04-08-26_msedge](https://user-images.githubusercontent.com/3516343/155014020-dee23470-1ad7-4f21-8761-94b15ac1975a.png)

