### PR TITLE
formatToPartsの戻り値に複数のintegerが含まれていた場合1つ目のintegerしか表示されない問題を修正

### DIFF
--- a/src/ui/components/FarmingStats/Profit.tsx
+++ b/src/ui/components/FarmingStats/Profit.tsx
@@ -30,14 +30,14 @@ export const Profit: React.VFC<{
                 <div className="grid grid-cols-3 gap-3">
                     <ResourceCounter
                         type="parts"
-                        sign
+                        showSign
                         amount={
                             resources.parts - currentSquadCosts.parts * lapCount
                         }
                     />
                     <ResourceCounter
                         type="nutrient"
-                        sign
+                        showSign
                         amount={
                             resources.nutrients -
                             currentSquadCosts.nutrients * lapCount
@@ -45,7 +45,7 @@ export const Profit: React.VFC<{
                     />
                     <ResourceCounter
                         type="power"
-                        sign
+                        showSign
                         amount={
                             resources.power - currentSquadCosts.power * lapCount
                         }


### PR DESCRIPTION
formatToPartsの戻り値に複数のintegerが含まれていた場合1つ目のintegerしか表示されない問題を修正
### before
![image](https://user-images.githubusercontent.com/3516343/155268325-896aed72-04fa-48b2-92eb-4167be00f43b.png)
### after
![image](https://user-images.githubusercontent.com/3516343/155268329-b74577eb-10d0-4866-b6ad-28defc41691d.png)
