### PR TITLE
UAに"Chrome"が含まれていない場合UAを偽装する

### DIFF
--- a/src/banner.js
+++ b/src/banner.js
@@ -6,7 +6,7 @@
 // @description ブラウザ版ラストオリジンのプレイを支援する Userscript
 // @homepageURL https://github.com/eai04191/laoplus
 // @supportURL  https://github.com/eai04191/laoplus/issues
-// @run-at      document-idle
+// @run-at      document-end
 // @match       https://pc-play.games.dmm.co.jp/play/lastorigin_r/*
 // @match       https://pc-play.games.dmm.com/play/lastorigin/*
 // @match       https://osapi.dmm.com/gadgets/ifr?synd=dmm&container=dmm&owner=*&viewer=*&aid=616121&*

--- a/src/features/resizeObserver/index.ts
+++ b/src/features/resizeObserver/index.ts
@@ -1,6 +1,10 @@
 import { log } from "~/utils";
 
-export const initResizeObserver = () => {
+export const initResizeObserver = async () => {
+    const waitFor = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
+    await waitFor(1000);
+
     const game = document.querySelector("canvas");
     if (!game) {
         log.error("ResizeObserver", "Game Canvas Not Found");

--- a/src/injection/dmmInner.ts
+++ b/src/injection/dmmInner.ts
@@ -1,6 +1,21 @@
 import { log } from "../utils/log";
 
 export const initDMMInnerPage = () => {
+    // UA偽装
+    if (!navigator.userAgent.includes("Chrome")) {
+        const originalUA = navigator.userAgent;
+        Object.defineProperty(navigator, "userAgent", {
+            value: `Chrome/99.99.99.99 (Spoofed by LAOPLUS) (${originalUA})`,
+            configurable: false,
+        });
+        log.log(
+            "Injection",
+            "DMM Inner Page",
+            "UA spoofed",
+            navigator.userAgent
+        );
+    }
+
     const frame = document.querySelector<HTMLIFrameElement>("#my_frame");
     if (frame === null) return;
 


### PR DESCRIPTION
これによりLAOPLUS単独でFirefoxで起動できるようになる
![image](https://user-images.githubusercontent.com/3516343/155295935-7f0c9e90-2bbb-4bbc-b54d-0929970c1a2a.png)
