### PR TITLE
ScrollPatchをUIScrollViewにも適用する・リスト範囲外へのスクロールをさせないオプションを追加

### DIFF
--- a/Feature/ScrollTweak.cs
+++ b/Feature/ScrollTweak.cs
@@ -1,3 +1,4 @@
+using System;
 using HarmonyLib;
 
 namespace LAOPLUS.Feature
@@ -5,15 +6,50 @@ namespace LAOPLUS.Feature
     /// <summary>
     /// ホイールスクロールに関連する機能
     /// </summary>
-    [HarmonyPatch(typeof(UIReuseScrollView), nameof(UIReuseScrollView.Scroll))]
+    [HarmonyPatch]
     public static class ScrollTweak
     {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(UIReuseScrollView), nameof(UIReuseScrollView.Scroll))]
+        [HarmonyPatch(typeof(UIScrollView), nameof(UIScrollView.Scroll))]
         static void Prefix(ref float delta)
         {
             delta = delta * LAOPLUS.ConfigScrollPatchMultiplier.Value;
             if (LAOPLUS.ConfigVerboseLogging.Value)
             {
                 LAOPLUS.Log.LogInfo($"ScrollPatch: {delta}");
+            }
+        }
+
+        [HarmonyPatch(
+            typeof(UIReuseScrollView),
+            nameof(UIReuseScrollView.RestrictWithinBounds),
+            new[] { typeof(bool), typeof(bool), typeof(bool) }
+        )]
+        public static class ScrollingOoBPatchForUIReuseScrollView
+        {
+            static void Prefix(UIReuseScrollView __instance)
+            {
+                if (LAOPLUS.ConfigDisableScrollingOoB.Value)
+                {
+                    __instance.dragEffect = UIReuseScrollView.DragEffect.Momentum;
+                }
+            }
+        }
+
+        [HarmonyPatch(
+            typeof(UIScrollView),
+            nameof(UIScrollView.RestrictWithinBounds),
+            new[] { typeof(bool), typeof(bool), typeof(bool) }
+        )]
+        public static class ScrollingOoBPatchForUIScrollView
+        {
+            static void Prefix(UIScrollView __instance)
+            {
+                if (LAOPLUS.ConfigDisableScrollingOoB.Value)
+                {
+                    __instance.dragEffect = UIScrollView.DragEffect.Momentum;
+                }
             }
         }
     }

--- a/LAOPLUS.cs
+++ b/LAOPLUS.cs
@@ -27,6 +27,7 @@ namespace LAOPLUS
 
         // ScrollPatch
         public static ConfigEntry<float> ConfigScrollPatchMultiplier;
+        public static ConfigEntry<bool> ConfigDisableScrollingOoB;
 
         public static readonly List<INotificationClient> NotificationClients = new();
 
@@ -67,12 +68,18 @@ namespace LAOPLUS
                 NotificationClients.Add(discord);
             }
 
-            // ScrollPatch
+            // ScrollTweak
             ConfigScrollPatchMultiplier = Config.Bind(
                 "Scroll Patch",
                 "スクロール倍率",
                 6.0f,
                 "戦闘員・装備リストなどのホイールスクロール倍率"
+            );
+            ConfigDisableScrollingOoB = Config.Bind(
+                "Scroll Patch",
+                "範囲外へのスクロールを無効にする",
+                true,
+                "リストでのスクロール時に項目の範囲外までスクロールしないようにします"
             );
 
             Log.LogInfo($"{NotificationClients.Count} notification client(s) loaded.");


### PR DESCRIPTION
https://user-images.githubusercontent.com/3516343/172196995-37be6d38-04a1-4e85-a093-6aa4acce43a4.mp4

リスト範囲外へのスクロールを抑制するオプションは次のようにリストが小さい場合に役立ちます:

https://user-images.githubusercontent.com/3516343/172197360-640b16fa-742c-407c-adf4-1c9bc70fc4b4.mp4

https://user-images.githubusercontent.com/3516343/172197480-87d73150-bb8f-420b-8c28-9748534a67f0.mp4


